### PR TITLE
Enable only one call a time

### DIFF
--- a/BridgeExample/websocket.htm
+++ b/BridgeExample/websocket.htm
@@ -11,7 +11,7 @@
 		<input type="radio" name="paymentMethod" id="Credit" value="Credit"/><label for="Credit">Credit</label>
 		<input type="radio" name="paymentMethod" id="Debit" value="Debit"/><label for="Debit">Debit</label>
 		<br />
-		<button onclick="webSocket.call()" id="sender" class="block">SEND!</button>
+		<button onclick="callWS()" id="sender" class="block">SEND!</button>
 	</div>
 </body>
 </html>


### PR DESCRIPTION
Stop processing and answer that only one call is allowed a time when 
try to process a transaction if another one did not finish yet.

Change the javascript example to not mix two concurrent calls.