### PR TITLE
tls: fix api communication

### DIFF
--- a/PagarMe.Mpos/PagarMe.Mpos.csproj
+++ b/PagarMe.Mpos/PagarMe.Mpos.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Devices\IDevice.cs" />
     <Compile Include="Devices\SerialDevice.cs" />
     <Compile Include="Properties\MposAssemblyInfo.cs" />
+    <Compile Include="TLS.cs" />
     <Compile Include="Tms\Bit32.cs" />
     <Compile Include="Tms\Linux.cs" />
     <Compile Include="Tms\Bit64.cs" />

--- a/PagarMe.Mpos/TLS.cs
+++ b/PagarMe.Mpos/TLS.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace PagarMe.Mpos
+{
+    public class TLS
+    {
+        /// <summary>
+        /// Changes the default protocol to TLS 1.2
+        /// to run the request that needs this protocol
+        /// then return to previous configuration
+        /// </summary>
+        public static async Task<T> RunWithTLS12<T>(Func<Task<T>> requestCode)
+        {
+            var defaultProtocol = ServicePointManager.SecurityProtocol;
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            var result = await requestCode();
+
+            ServicePointManager.SecurityProtocol = defaultProtocol;
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
The api, after 2018-06-21, will only accept communication using
TLS 1.2, for security reasons.