### PR TITLE
example: remove close from before finish

### DIFF
--- a/PagarMe.Mpos.Example/PaymentProcessor.cs
+++ b/PagarMe.Mpos.Example/PaymentProcessor.cs
@@ -40,9 +40,6 @@ namespace PagarMe.Mpos.Example
             var result = await mpos.ProcessPayment(amount, null, PaymentMethod.Debit);
             Console.WriteLine("CARD HASH = " + result.CardHash);
 
-            await mpos.Close();
-            Console.WriteLine("CLOSED!");
-
             if (result.Status == PaymentStatus.Accepted)
             {
                 var transaction = new Transaction
@@ -70,6 +67,7 @@ namespace PagarMe.Mpos.Example
             }
 
             await mpos.Close();
+            Console.WriteLine("CLOSED!");
         }
     }
 }


### PR DESCRIPTION
The example program was closing the connection before of a call to finish the transaction.

This PR removes this mistake and add the Console.WriteLine (that were at the first call to close) to the right call.